### PR TITLE
Fix example code execution and heat map path

### DIFF
--- a/bio_algos/heat_map.py
+++ b/bio_algos/heat_map.py
@@ -79,7 +79,8 @@ def heat_maps(
     matrix = compute_similarity_matrix(nuc_list)
     plot_heatmap(matrix, organisms, output_file, show)
 
-# Example usage:
-nuc_list = ["ATGCATGC", "ATGCGGGC", "TTTTCATC"]
-organisms = ["Organism A", "Organism B", "Organism C"]
-heat_maps(nuc_list, organisms, "similarity_heatmap.png", show=True)
+if __name__ == "__main__":
+    # Example usage:
+    nuc_list = ["ATGCATGC", "ATGCGGGC", "TTTTCATC"]
+    organisms = ["Organism A", "Organism B", "Organism C"]
+    heat_maps(nuc_list, organisms, "similarity_heatmap.png", show=True)

--- a/bio_algos/stacked_bar_chart.py
+++ b/bio_algos/stacked_bar_chart.py
@@ -51,7 +51,8 @@ def grouped_bar_chart(nuc_list, organisms, output=None, show=False):
         plt.show()
     plt.close(fig)
 
-# Example usage:
-nuc_list = ['GATTTGCA', 'GATTACA', 'GCGCGCAT']
-organisms = ['Human', 'Mouse', 'Yeast']
-grouped_bar_chart(nuc_list, organisms, output='nuc_freq.png', show=True)
+if __name__ == "__main__":
+    # Example usage:
+    nuc_list = ['GATTTGCA', 'GATTACA', 'GCGCGCAT']
+    organisms = ['Human', 'Mouse', 'Yeast']
+    grouped_bar_chart(nuc_list, organisms, output='nuc_freq.png', show=True)

--- a/routes.py
+++ b/routes.py
@@ -134,7 +134,9 @@ def compile_report():
                 bio_algos.dot_plot.dot_plot(sequences, [organisms[i], organisms[j]],
                                             f"./static/graphs/dot_plot/dot{report.id}-{i}.png")
                 # create heat map
-                heat_paths.append(f"./static/images/graphs/heat_map/heat{report.id}-{i}.png")
+                heat_paths.append(
+                    f"./static/graphs/heat_map/heat{report.id}-{i}.png"
+                )
                 heat_map.heat_map(sequences, [organisms[i], organisms[j]],
                                   f"./static/graphs/heat_map/heat{report.id}-{i}.png")
 


### PR DESCRIPTION
## Summary
- ensure heat map and stacked bar chart examples only run when invoked directly
- correct heat map path when saving report graphs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fe059504c8326854805e4ec83b9b0