### PR TITLE
Add GC content line graph feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ BioKit is a Flask web application offering researchers a simple interface for pr
 - Asynchronous job queue powered by Celery
 - JSON API endpoints for automation
 - Docker configuration for easy deployment
+- GC content line graphs for individual sequences
 
 ## Quick start
 1. Create a virtual environment and install the dependencies

--- a/bio_algos/gc_content_line.py
+++ b/bio_algos/gc_content_line.py
@@ -1,0 +1,32 @@
+import matplotlib.pyplot as plt
+from typing import List, Optional
+
+
+def calculate_gc_content(sequence: str, window: int = 50) -> List[float]:
+    """Return GC fraction for each sliding window in the sequence."""
+    sequence = sequence.upper()
+    if window < 1 or window > len(sequence):
+        window = len(sequence)
+    values = []
+    for i in range(len(sequence) - window + 1):
+        window_seq = sequence[i:i + window]
+        gc = (window_seq.count('G') + window_seq.count('C')) / window
+        values.append(gc)
+    return values
+
+
+def gc_line_graph(nuc_string: str, output: Optional[str] = None, window: int = 50, show: bool = False) -> None:
+    """Plot GC content along a sequence."""
+    gc_content = calculate_gc_content(nuc_string, window)
+    positions = list(range(1, len(gc_content) + 1))
+    fig, ax = plt.subplots(figsize=(10, 6))
+    ax.plot(positions, gc_content, linewidth=1)
+    ax.set_xlabel("Position")
+    ax.set_ylabel("GC content")
+    ax.set_title("GC Content Across Sequence")
+    plt.tight_layout()
+    if output:
+        plt.savefig(output, format='png', dpi=300, bbox_inches='tight')
+    if show:
+        plt.show()
+    plt.close(fig)

--- a/models.py
+++ b/models.py
@@ -96,6 +96,7 @@ class Report(db.Model):
     dot_line_graph = db.Column(db.JSON)
     heat_map = db.Column(db.JSON)
     bar_chart = db.Column(db.String(50))
+    gc_line_graphs = db.Column(db.JSON)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
     employee = db.relationship("User", backref="reports")

--- a/tasks.py
+++ b/tasks.py
@@ -4,6 +4,7 @@ from flask_bio_app import create_app
 from models import Record, Report, db
 from bio_algos.phylo_tree import generate_tree
 from bio_algos import dot_plot, heat_map, stacked_bar_chart
+from bio_algos.gc_content_line import gc_line_graph
 
 app = create_app()
 celery = app.celery
@@ -64,6 +65,13 @@ def compile_report_task(employee_id):
     bar_chart_path = f"./static/graphs/stacked_bar/bar{report.id}.png"
     stacked_bar_chart.stacked_bar_chart(nucleotides, organisms, bar_chart_path)
     report.bar_chart = bar_chart_path
+
+    gc_paths = []
+    for idx, seq in enumerate(nucleotides):
+        line_path = f"./static/graphs/gc_line/line{report.id}-{idx}.png"
+        gc_line_graph(seq, output=line_path)
+        gc_paths.append(line_path)
+    report.gc_line_graphs = gc_paths
 
     db.session.commit()
     return report.id

--- a/templates/display_report.html
+++ b/templates/display_report.html
@@ -143,7 +143,8 @@ Report
     {% endfor %}
 
 <div class="row">
-  {% set image_types = ['bar', 'heat', 'dot'] %}
+  {% set image_types = ['bar', 'heat', 'dot', 'line'] %}
+  {% set graph_folders = graph_images.keys() %}
   {% set reordered_folders = graph_folders|sort(reverse=True) %}
   {% for folder in reordered_folders %}
   <div class="col-md-6">

--- a/tests/test_gc_line.py
+++ b/tests/test_gc_line.py
@@ -1,0 +1,12 @@
+import os
+from bio_algos.gc_content_line import calculate_gc_content, gc_line_graph
+
+def test_calculate_gc_content():
+    vals = calculate_gc_content("GCGCGC", window=2)
+    assert vals[0] == 1.0
+    assert len(vals) == 5
+
+def test_gc_line_graph_tmp(tmp_path):
+    out = tmp_path / "out.png"
+    gc_line_graph("ATGCATGC", output=str(out))
+    assert out.exists()


### PR DESCRIPTION
## Summary
- generate GC content line graphs for each sequence
- include new graph paths in reports
- display GC line graphs in the report view
- update tasks and models for new graph type
- document new capability in README
- add basic tests for GC line graph generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68614e3f876483269a1362d476e0a264