### PR TITLE
Add GC content heatmap visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ BioKit is a Flask web application offering researchers a simple interface for pr
 - JSON API endpoints for automation
 - Docker configuration for easy deployment
 - GC content line graphs for individual sequences
+- GC content heatmaps comparing multiple sequences
 
 ## Quick start
 1. Create a virtual environment and install the dependencies

--- a/bio_algos/gc_content_heatmap.py
+++ b/bio_algos/gc_content_heatmap.py
@@ -1,0 +1,46 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from typing import List, Optional
+
+from .gc_content_line import calculate_gc_content
+
+
+def gc_content_heatmap(
+    sequences: List[str],
+    labels: List[str],
+    window: int = 50,
+    output: Optional[str] = None,
+    show: bool = False,
+) -> None:
+    """Generate a heatmap of GC content across multiple sequences."""
+    if len(sequences) != len(labels):
+        raise ValueError("Number of sequences and labels must match.")
+
+    gc_matrix: List[List[float]] = []
+    max_len = 0
+    for seq in sequences:
+        gc_vals = calculate_gc_content(seq, window)
+        gc_matrix.append(gc_vals)
+        max_len = max(max_len, len(gc_vals))
+
+    # Pad shorter sequences with NaNs for uniform heatmap size
+    padded = [vals + [np.nan] * (max_len - len(vals)) for vals in gc_matrix]
+    data = np.array(padded)
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+    im = ax.imshow(data, aspect='auto', cmap='viridis', interpolation='none')
+
+    ax.set_yticks(np.arange(len(labels)))
+    ax.set_yticklabels(labels)
+    ax.set_xlabel("Window position")
+    ax.set_title("GC Content Heatmap")
+    cbar = fig.colorbar(im, ax=ax)
+    cbar.ax.set_ylabel("GC fraction", rotation=-90, va="bottom")
+
+    plt.tight_layout()
+
+    if output:
+        plt.savefig(output, format='png', dpi=300, bbox_inches='tight')
+    if show:
+        plt.show()
+    plt.close(fig)

--- a/tests/test_gc_heatmap.py
+++ b/tests/test_gc_heatmap.py
@@ -1,0 +1,10 @@
+import os
+from bio_algos.gc_content_heatmap import gc_content_heatmap
+
+
+def test_gc_content_heatmap_tmp(tmp_path):
+    out = tmp_path / "heat.png"
+    sequences = ["ATGCATGC", "GGGCCC", "ATATATAT"]
+    labels = ["seq1", "seq2", "seq3"]
+    gc_content_heatmap(sequences, labels, window=2, output=str(out))
+    assert out.exists()


### PR DESCRIPTION
## Summary
- add GC content heatmap graph to `bio_algos`
- test heatmap image generation
- document new heatmap feature in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68627e4552248326a8b03a76a9525d85