### PR TITLE
Add GC skew graph visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ BioKit is a Flask web application offering researchers a simple interface for pr
 - Docker configuration for easy deployment
 - GC content line graphs for individual sequences
 - GC content heatmaps comparing multiple sequences
+- GC skew plots highlighting replication biases
 
 ## Quick start
 1. Create a virtual environment and install the dependencies

--- a/bio_algos/gc_skew.py
+++ b/bio_algos/gc_skew.py
@@ -1,0 +1,41 @@
+import matplotlib.pyplot as plt
+from typing import List, Optional
+
+
+def calculate_gc_skew(sequence: str, window: int = 50) -> List[float]:
+    """Return GC skew for each sliding window in the sequence."""
+    sequence = sequence.upper()
+    if window < 1 or window > len(sequence):
+        window = len(sequence)
+    skew_values: List[float] = []
+    for i in range(len(sequence) - window + 1):
+        window_seq = sequence[i:i + window]
+        g = window_seq.count('G')
+        c = window_seq.count('C')
+        total = g + c
+        skew = (g - c) / total if total else 0.0
+        skew_values.append(skew)
+    return skew_values
+
+
+def gc_skew_plot(nuc_string: str, output: Optional[str] = None,
+                  window: int = 50, show: bool = False) -> None:
+    """Plot GC skew across a nucleotide sequence."""
+    skew = calculate_gc_skew(nuc_string, window)
+    positions = list(range(1, len(skew) + 1))
+    fig, ax = plt.subplots(figsize=(10, 6))
+    ax.plot(positions, skew, color='purple', linewidth=1)
+    ax.axhline(0, color='black', linestyle='--', linewidth=0.8)
+    ax.fill_between(positions, 0, skew, where=[s >= 0 for s in skew],
+                    color='violet', alpha=0.3)
+    ax.fill_between(positions, 0, skew, where=[s < 0 for s in skew],
+                    color='lightblue', alpha=0.3)
+    ax.set_xlabel("Position")
+    ax.set_ylabel("GC Skew")
+    ax.set_title("GC Skew Across Sequence")
+    plt.tight_layout()
+    if output:
+        plt.savefig(output, format='png', dpi=300, bbox_inches='tight')
+    if show:
+        plt.show()
+    plt.close(fig)

--- a/flask_bio_app.py
+++ b/flask_bio_app.py
@@ -48,6 +48,7 @@ from bio_algos import (
     siRNA, utilities, stacked_bar_chart, heat_map
 )
 from bio_algos.gc_content_line import gc_line_graph
+from bio_algos.gc_skew import gc_skew_plot
 
 # Configure logging
 logging.basicConfig(
@@ -245,7 +246,8 @@ class ReportGenerator:
             'dot_plots': [],
             'heat_maps': [],
             'bar_chart': None,
-            'gc_lines': []
+            'gc_lines': [],
+            'gc_skews': []
         }
         
         try:
@@ -255,7 +257,8 @@ class ReportGenerator:
                 'static/graphs/dot_plot',
                 'static/graphs/heat_map',
                 'static/graphs/stacked_bar',
-                'static/graphs/gc_line'
+                'static/graphs/gc_line',
+                'static/graphs/gc_skew'
             ]
             for dir_path in graph_dirs:
                 Path(dir_path).mkdir(parents=True, exist_ok=True)
@@ -286,11 +289,15 @@ class ReportGenerator:
             stacked_bar_chart.stacked_bar_chart(nucleotides, organisms, bar_path)
             graph_paths['bar_chart'] = bar_path
 
-            # Generate GC content line graphs for each sequence
+            # Generate GC content line graphs and GC skew plots for each sequence
             for idx, seq in enumerate(nucleotides):
                 line_path = f"static/graphs/gc_line/line{report_id}-{idx}.png"
                 gc_line_graph(seq, output=line_path)
                 graph_paths['gc_lines'].append(line_path)
+
+                skew_path = f"static/graphs/gc_skew/skew{report_id}-{idx}.png"
+                gc_skew_plot(seq, output=skew_path)
+                graph_paths['gc_skews'].append(skew_path)
 
             return graph_paths
             
@@ -368,7 +375,7 @@ class PDFReportGenerator:
         • Dot plots for sequence similarity visualization
         • Heat maps for detailed sequence comparison
         • Nucleotide composition bar chart
-        
+        • GC content trends and GC skew plots
         Generated graphs are available in the web interface.
         """
         story.append(Paragraph(analysis_text, styles['Normal']))
@@ -543,7 +550,7 @@ def display_report(report_id):
     graph_images = {}
     graph_base_path = Path('static/graphs')
 
-    for folder in ['phylo_tree', 'dot_plot', 'heat_map', 'stacked_bar', 'gc_line']:
+    for folder in ['phylo_tree', 'dot_plot', 'heat_map', 'stacked_bar', 'gc_line', 'gc_skew']:
         folder_path = graph_base_path / folder
         if folder_path.exists():
             images = [
@@ -744,6 +751,7 @@ def compile_report_task(self, user_id):
         report.heat_map = graph_paths['heat_maps']
         report.bar_chart = graph_paths['bar_chart']
         report.gc_line_graphs = graph_paths['gc_lines']
+        report.gc_skew_graphs = graph_paths['gc_skews']
         
         # Associate records
         report.associated_records.extend(records)

--- a/models.py
+++ b/models.py
@@ -97,6 +97,7 @@ class Report(db.Model):
     heat_map = db.Column(db.JSON)
     bar_chart = db.Column(db.String(50))
     gc_line_graphs = db.Column(db.JSON)
+    gc_skew_graphs = db.Column(db.JSON)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
     employee = db.relationship("User", backref="reports")

--- a/tasks.py
+++ b/tasks.py
@@ -5,6 +5,7 @@ from models import Record, Report, db
 from bio_algos.phylo_tree import generate_tree
 from bio_algos import dot_plot, heat_map, stacked_bar_chart
 from bio_algos.gc_content_line import gc_line_graph
+from bio_algos.gc_skew import gc_skew_plot
 
 app = create_app()
 celery = app.celery
@@ -67,11 +68,17 @@ def compile_report_task(employee_id):
     report.bar_chart = bar_chart_path
 
     gc_paths = []
+    skew_paths = []
     for idx, seq in enumerate(nucleotides):
         line_path = f"./static/graphs/gc_line/line{report.id}-{idx}.png"
         gc_line_graph(seq, output=line_path)
         gc_paths.append(line_path)
+
+        skew_path = f"./static/graphs/gc_skew/skew{report.id}-{idx}.png"
+        gc_skew_plot(seq, output=skew_path)
+        skew_paths.append(skew_path)
     report.gc_line_graphs = gc_paths
+    report.gc_skew_graphs = skew_paths
 
     db.session.commit()
     return report.id

--- a/templates/display_report.html
+++ b/templates/display_report.html
@@ -143,7 +143,7 @@ Report
     {% endfor %}
 
 <div class="row">
-  {% set image_types = ['bar', 'heat', 'dot', 'line'] %}
+  {% set image_types = ['bar', 'heat', 'dot', 'line', 'skew'] %}
   {% set graph_folders = graph_images.keys() %}
   {% set reordered_folders = graph_folders|sort(reverse=True) %}
   {% for folder in reordered_folders %}

--- a/tests/test_gc_skew.py
+++ b/tests/test_gc_skew.py
@@ -1,0 +1,13 @@
+from bio_algos.gc_skew import calculate_gc_skew, gc_skew_plot
+
+
+def test_calculate_gc_skew():
+    vals = calculate_gc_skew("GCGC", window=2)
+    assert vals[0] == 0.0
+    assert len(vals) == 3
+
+
+def test_gc_skew_plot_tmp(tmp_path):
+    out = tmp_path / "skew.png"
+    gc_skew_plot("ATGCGCGTAT", output=str(out))
+    assert out.exists()


### PR DESCRIPTION
## Summary
- implement new GC skew plot in `bio_algos`
- generate GC skew graphs when building reports
- display GC skew graphs in the web UI
- track new graph paths in models and Celery tasks
- mention GC skew plots in README and PDF report text
- test GC skew utilities

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863dcbf79d8832689cdd3877a747197