### PR TITLE
Add nucleotide composition pie chart graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ BioKit is a Flask web application offering researchers a simple interface for pr
 - GC content line graphs for individual sequences
 - GC content heatmaps comparing multiple sequences
 - GC skew plots highlighting replication biases
+- Nucleotide composition pie charts for each sequence
 
 ## Quick start
 1. Create a virtual environment and install the dependencies

--- a/bio_algos/nucleotide_pie.py
+++ b/bio_algos/nucleotide_pie.py
@@ -1,0 +1,37 @@
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+from typing import Optional, Dict
+
+
+def nucleotide_frequencies(seq: str) -> Dict[str, float]:
+    """Calculate normalized nucleotide frequencies for A, T, G, C."""
+    seq = seq.upper()
+    counts = {base: seq.count(base) for base in 'ATGC'}
+    total = sum(counts.values())
+    if total == 0:
+        raise ValueError("Sequence contains no nucleotides")
+    return {base: counts[base] / total for base in 'ATGC'}
+
+
+def nucleotide_pie_chart(
+    seq: str,
+    output: Optional[str] = None,
+    show: bool = False
+) -> None:
+    """Generate a pie chart of nucleotide composition."""
+    freqs = nucleotide_frequencies(seq)
+    labels = [f"{b} ({freqs[b]*100:.1f}%)" for b in 'ATGC']
+    sizes = [freqs[b] for b in 'ATGC']
+    colors = ['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728']
+
+    fig, ax = plt.subplots(figsize=(4, 4))
+    wedges, texts = ax.pie(sizes, labels=labels, colors=colors, startangle=90)
+    ax.axis('equal')
+    ax.set_title('Nucleotide Composition')
+
+    if output:
+        plt.savefig(output, format='png', dpi=300, bbox_inches='tight')
+    if show:
+        plt.show()
+    plt.close(fig)

--- a/flask_bio_app.py
+++ b/flask_bio_app.py
@@ -49,6 +49,7 @@ from bio_algos import (
 )
 from bio_algos.gc_content_line import gc_line_graph
 from bio_algos.gc_skew import gc_skew_plot
+from bio_algos.nucleotide_pie import nucleotide_pie_chart
 
 # Configure logging
 logging.basicConfig(
@@ -247,7 +248,8 @@ class ReportGenerator:
             'heat_maps': [],
             'bar_chart': None,
             'gc_lines': [],
-            'gc_skews': []
+            'gc_skews': [],
+            'nuc_pies': []
         }
         
         try:
@@ -258,7 +260,8 @@ class ReportGenerator:
                 'static/graphs/heat_map',
                 'static/graphs/stacked_bar',
                 'static/graphs/gc_line',
-                'static/graphs/gc_skew'
+                'static/graphs/gc_skew',
+                'static/graphs/nuc_pie'
             ]
             for dir_path in graph_dirs:
                 Path(dir_path).mkdir(parents=True, exist_ok=True)
@@ -289,7 +292,7 @@ class ReportGenerator:
             stacked_bar_chart.stacked_bar_chart(nucleotides, organisms, bar_path)
             graph_paths['bar_chart'] = bar_path
 
-            # Generate GC content line graphs and GC skew plots for each sequence
+            # Generate GC content line graphs, GC skew plots, and nucleotide pie charts
             for idx, seq in enumerate(nucleotides):
                 line_path = f"static/graphs/gc_line/line{report_id}-{idx}.png"
                 gc_line_graph(seq, output=line_path)
@@ -298,6 +301,10 @@ class ReportGenerator:
                 skew_path = f"static/graphs/gc_skew/skew{report_id}-{idx}.png"
                 gc_skew_plot(seq, output=skew_path)
                 graph_paths['gc_skews'].append(skew_path)
+
+                pie_path = f"static/graphs/nuc_pie/pie{report_id}-{idx}.png"
+                nucleotide_pie_chart(seq, output=pie_path)
+                graph_paths['nuc_pies'].append(pie_path)
 
             return graph_paths
             
@@ -550,7 +557,7 @@ def display_report(report_id):
     graph_images = {}
     graph_base_path = Path('static/graphs')
 
-    for folder in ['phylo_tree', 'dot_plot', 'heat_map', 'stacked_bar', 'gc_line', 'gc_skew']:
+    for folder in ['phylo_tree', 'dot_plot', 'heat_map', 'stacked_bar', 'gc_line', 'gc_skew', 'nuc_pie']:
         folder_path = graph_base_path / folder
         if folder_path.exists():
             images = [
@@ -752,6 +759,7 @@ def compile_report_task(self, user_id):
         report.bar_chart = graph_paths['bar_chart']
         report.gc_line_graphs = graph_paths['gc_lines']
         report.gc_skew_graphs = graph_paths['gc_skews']
+        report.nuc_pie_charts = graph_paths['nuc_pies']
         
         # Associate records
         report.associated_records.extend(records)

--- a/models.py
+++ b/models.py
@@ -98,6 +98,7 @@ class Report(db.Model):
     bar_chart = db.Column(db.String(50))
     gc_line_graphs = db.Column(db.JSON)
     gc_skew_graphs = db.Column(db.JSON)
+    nuc_pie_charts = db.Column(db.JSON)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
     employee = db.relationship("User", backref="reports")

--- a/tasks.py
+++ b/tasks.py
@@ -6,6 +6,7 @@ from bio_algos.phylo_tree import generate_tree
 from bio_algos import dot_plot, heat_map, stacked_bar_chart
 from bio_algos.gc_content_line import gc_line_graph
 from bio_algos.gc_skew import gc_skew_plot
+from bio_algos.nucleotide_pie import nucleotide_pie_chart
 
 app = create_app()
 celery = app.celery
@@ -69,6 +70,7 @@ def compile_report_task(employee_id):
 
     gc_paths = []
     skew_paths = []
+    pie_paths = []
     for idx, seq in enumerate(nucleotides):
         line_path = f"./static/graphs/gc_line/line{report.id}-{idx}.png"
         gc_line_graph(seq, output=line_path)
@@ -77,8 +79,13 @@ def compile_report_task(employee_id):
         skew_path = f"./static/graphs/gc_skew/skew{report.id}-{idx}.png"
         gc_skew_plot(seq, output=skew_path)
         skew_paths.append(skew_path)
+
+        pie_path = f"./static/graphs/nuc_pie/pie{report.id}-{idx}.png"
+        nucleotide_pie_chart(seq, output=pie_path)
+        pie_paths.append(pie_path)
     report.gc_line_graphs = gc_paths
     report.gc_skew_graphs = skew_paths
+    report.nuc_pie_charts = pie_paths
 
     db.session.commit()
     return report.id

--- a/templates/display_report.html
+++ b/templates/display_report.html
@@ -143,7 +143,7 @@ Report
     {% endfor %}
 
 <div class="row">
-  {% set image_types = ['bar', 'heat', 'dot', 'line', 'skew'] %}
+  {% set image_types = ['bar', 'heat', 'dot', 'line', 'skew', 'pie'] %}
   {% set graph_folders = graph_images.keys() %}
   {% set reordered_folders = graph_folders|sort(reverse=True) %}
   {% for folder in reordered_folders %}

--- a/tests/test_nucleotide_pie.py
+++ b/tests/test_nucleotide_pie.py
@@ -1,0 +1,13 @@
+from bio_algos.nucleotide_pie import nucleotide_pie_chart, nucleotide_frequencies
+
+
+def test_nucleotide_frequencies():
+    freqs = nucleotide_frequencies('AATTGGCC')
+    assert abs(freqs['A'] - 0.25) < 1e-6
+    assert sum(freqs.values()) == 1.0
+
+
+def test_nucleotide_pie_chart(tmp_path):
+    out = tmp_path / 'pie.png'
+    nucleotide_pie_chart('ATGCATGC', output=str(out))
+    assert out.exists()


### PR DESCRIPTION
## Summary
- add nucleotide pie chart graph algorithm and tests
- generate pie charts for sequences when compiling reports
- display pie charts in reports
- store pie chart paths on Report model
- document the new visualization in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68652e98b934832693fb67f3718a0193