### PR TITLE
Add sequence entropy visualization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 #db.sqlite3
 #requirements.txt
 ncbi_cache/
+__pycache__/
+*.png

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ BioKit is a Flask web application offering researchers a simple interface for pr
 - GC content heatmaps comparing multiple sequences
 - GC skew plots highlighting replication biases
 - Nucleotide composition pie charts for each sequence
+- Sequence entropy line graphs showing local complexity
 
 ## Quick start
 1. Create a virtual environment and install the dependencies

--- a/bio_algos/entropy_line.py
+++ b/bio_algos/entropy_line.py
@@ -1,0 +1,50 @@
+import numpy as np
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+from typing import List, Optional
+
+
+def shannon_entropy(window_seq: str) -> float:
+    """Calculate Shannon entropy of a nucleotide window."""
+    window_seq = window_seq.upper()
+    length = len(window_seq)
+    if length == 0:
+        return 0.0
+    bases = ['A', 'T', 'G', 'C']
+    freqs = [window_seq.count(b) / length for b in bases]
+    return -sum(p * np.log2(p) for p in freqs if p > 0)
+
+
+def calculate_entropy(sequence: str, window: int = 50) -> List[float]:
+    """Return entropy values for each sliding window in the sequence."""
+    sequence = sequence.upper()
+    if window < 1 or window > len(sequence):
+        window = len(sequence)
+    values = []
+    for i in range(len(sequence) - window + 1):
+        window_seq = sequence[i:i + window]
+        values.append(shannon_entropy(window_seq))
+    return values
+
+
+def entropy_line_graph(
+    nuc_string: str,
+    output: Optional[str] = None,
+    window: int = 50,
+    show: bool = False,
+) -> None:
+    """Plot sequence entropy along a nucleotide sequence."""
+    entropies = calculate_entropy(nuc_string, window)
+    positions = list(range(1, len(entropies) + 1))
+    fig, ax = plt.subplots(figsize=(10, 6))
+    ax.plot(positions, entropies, color="orange", linewidth=1)
+    ax.set_xlabel("Position")
+    ax.set_ylabel("Shannon entropy")
+    ax.set_title("Sequence Entropy Across Window")
+    plt.tight_layout()
+    if output:
+        plt.savefig(output, format="png", dpi=300, bbox_inches="tight")
+    if show:
+        plt.show()
+    plt.close(fig)

--- a/tests/test_entropy_line.py
+++ b/tests/test_entropy_line.py
@@ -1,0 +1,18 @@
+from bio_algos.entropy_line import shannon_entropy, calculate_entropy, entropy_line_graph
+
+
+def test_shannon_entropy_values():
+    assert abs(shannon_entropy('AAAA') - 0.0) < 1e-6
+    assert abs(shannon_entropy('ATGC') - 2.0) < 1e-6
+
+
+def test_calculate_entropy():
+    vals = calculate_entropy('ATGCATGC', window=4)
+    assert len(vals) == 5
+    assert abs(vals[0] - 2.0) < 1e-6
+
+
+def test_entropy_line_graph(tmp_path):
+    out = tmp_path / 'entropy.png'
+    entropy_line_graph('ATGCATGC', output=str(out))
+    assert out.exists()


### PR DESCRIPTION
## Summary
- add Sequence entropy line graph algorithm
- test the entropy plotting utilities
- ignore caches and output images
- document the new visualization feature

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867047bbb34832689976d30c5761012