### PR TITLE
Add cumulative GC skew analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ BioKit is a Flask web application offering researchers a simple interface for pr
 - GC content line graphs for individual sequences
 - GC content heatmaps comparing multiple sequences
 - GC skew plots highlighting replication biases
+- Cumulative GC skew plots for detecting replication origins
 - Nucleotide composition pie charts for each sequence
 - Sequence entropy line graphs showing local complexity
 - K-mer frequency histograms for exploring motif patterns

--- a/bio_algos/cumulative_gc_skew.py
+++ b/bio_algos/cumulative_gc_skew.py
@@ -1,0 +1,38 @@
+import matplotlib.pyplot as plt
+from typing import List, Optional
+
+
+def calculate_cumulative_gc_skew(sequence: str) -> List[int]:
+    """Return the cumulative GC skew (G count minus C count) at each position."""
+    sequence = sequence.upper()
+    g_count = 0
+    c_count = 0
+    skew: List[int] = []
+    for base in sequence:
+        if base == 'G':
+            g_count += 1
+        elif base == 'C':
+            c_count += 1
+        skew.append(g_count - c_count)
+    return skew
+
+
+def cumulative_gc_skew_plot(
+    nuc_string: str,
+    output: Optional[str] = None,
+    show: bool = False,
+) -> None:
+    """Plot cumulative GC skew across a nucleotide sequence."""
+    skew = calculate_cumulative_gc_skew(nuc_string)
+    positions = list(range(1, len(skew) + 1))
+    fig, ax = plt.subplots(figsize=(10, 6))
+    ax.plot(positions, skew, color='green', linewidth=1)
+    ax.set_xlabel("Position")
+    ax.set_ylabel("Cumulative GC Skew (G - C)")
+    ax.set_title("Cumulative GC Skew")
+    plt.tight_layout()
+    if output:
+        plt.savefig(output, format='png', dpi=300, bbox_inches='tight')
+    if show:
+        plt.show()
+    plt.close(fig)

--- a/models.py
+++ b/models.py
@@ -101,6 +101,7 @@ class Report(db.Model):
     nuc_pie_charts = db.Column(db.JSON)
     entropy_line_graphs = db.Column(db.JSON)
     kmer_histograms = db.Column(db.JSON)
+    cumulative_gc_skew_graphs = db.Column(db.JSON)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
     employee = db.relationship("User", backref="reports")

--- a/tasks.py
+++ b/tasks.py
@@ -9,6 +9,7 @@ from bio_algos.gc_skew import gc_skew_plot
 from bio_algos.nucleotide_pie import nucleotide_pie_chart
 from bio_algos.entropy_line import entropy_line_graph
 from bio_algos.kmer_histogram import kmer_histogram
+from bio_algos.cumulative_gc_skew import cumulative_gc_skew_plot
 
 app = create_app()
 celery = app.celery
@@ -75,6 +76,7 @@ def compile_report_task(employee_id):
     pie_paths = []
     entropy_paths = []
     kmer_paths = []
+    cumulative_skew_paths = []
     for idx, seq in enumerate(nucleotides):
         line_path = f"./static/graphs/gc_line/line{report.id}-{idx}.png"
         gc_line_graph(seq, output=line_path)
@@ -95,11 +97,16 @@ def compile_report_task(employee_id):
         kmer_path = f"./static/graphs/kmer_hist/kmer{report.id}-{idx}.png"
         kmer_histogram(seq, k=3, output=kmer_path)
         kmer_paths.append(kmer_path)
+
+        cumul_path = f"./static/graphs/cumulative_skew/cumul{report.id}-{idx}.png"
+        cumulative_gc_skew_plot(seq, output=cumul_path)
+        cumulative_skew_paths.append(cumul_path)
     report.gc_line_graphs = gc_paths
     report.gc_skew_graphs = skew_paths
     report.nuc_pie_charts = pie_paths
     report.entropy_line_graphs = entropy_paths
     report.kmer_histograms = kmer_paths
+    report.cumulative_gc_skew_graphs = cumulative_skew_paths
 
     db.session.commit()
     return report.id

--- a/tests/test_cumulative_gc_skew.py
+++ b/tests/test_cumulative_gc_skew.py
@@ -1,0 +1,15 @@
+from bio_algos.cumulative_gc_skew import (
+    calculate_cumulative_gc_skew,
+    cumulative_gc_skew_plot,
+)
+
+
+def test_calculate_cumulative_gc_skew():
+    vals = calculate_cumulative_gc_skew("GCGC")
+    assert vals == [1, 0, 1, 0]
+
+
+def test_cumulative_gc_skew_plot(tmp_path):
+    out = tmp_path / "cumul.png"
+    cumulative_gc_skew_plot("ATGCGC", output=str(out))
+    assert out.exists()


### PR DESCRIPTION
## Summary
- add cumulative GC skew calculation and plotting
- store cumulative GC skew graphs when compiling reports
- track new graph paths in database models
- document the new visualization capability
- test cumulative GC skew utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fc116e8f48326a1d7b9342bf7988f